### PR TITLE
Add info for HYVE BSC

### DIFF
--- a/chains.json
+++ b/chains.json
@@ -1080,7 +1080,7 @@
 			    "DisableSwap": false,
 			    "IsDelegateContract": false
 		       }
-		}
+		},
 		"bcpv3": {
 			"srcChainID": "1",
 			"destChainID": "56",

--- a/chains.json
+++ b/chains.json
@@ -1039,6 +1039,48 @@
 				"IsDelegateContract": false
 			}
 		},
+		"hyve": {
+			"srcChainID": "1",
+			"destChainID": "56",
+			"PairID": "HYVE",
+			"SrcToken": {
+			    "ID": "ERC20",
+			    "Name": "HYVE",
+			    "Symbol": "HYVE",
+			    "Decimals": 18,
+			    "Description": "hyve.works",
+			    "DepositAddress": "0x533e3c0e6b48010873B947bddC4721b1bDFF9648", 
+			    "mpcAddress": "0x533e3c0e6b48010873B947bddC4721b1bDFF9648",
+			    "ContractAddress": "0xd794DD1CAda4cf79C9EebaAb8327a1B0507ef7d4",
+			    "MaximumSwap": 1000000,
+			    "MinimumSwap": 1,
+			    "BigValueThreshold": 200000,
+			    "SwapFeeRate": 0,
+			    "MaximumSwapFee": 0,
+			    "MinimumSwapFee": 0,
+			    "PlusGasPricePercentage": 10,
+			    "DisableSwap": false,
+			    "IsDelegateContract": false
+			},
+			"DestToken": {
+			    "ID": "HYVE",
+			    "Name": "HYVE",
+			    "Symbol": "HYVE",
+			    "Decimals": 18,
+			    "Description": "BSC cross chain bridge HYVE with HYVE",
+			    "mpcAddress": "0x533e3c0e6b48010873B947bddC4721b1bDFF9648",
+			    "ContractAddress": "0x014c374fd2641ab7a05d1875ca2ca2a0cf819198",
+			    "MaximumSwap": 1000000,
+			    "MinimumSwap": 1,
+			    "BigValueThreshold": 200000,
+			    "SwapFeeRate": 0.001,
+			    "MaximumSwapFee": 50,
+			    "MinimumSwapFee": 1,
+			    "PlusGasPricePercentage": 1,
+			    "DisableSwap": false,
+			    "IsDelegateContract": false
+		       }
+		}
 		"bcpv3": {
 			"srcChainID": "1",
 			"destChainID": "56",


### PR DESCRIPTION
- `0x014c374fd2641ab7a05d1875ca2ca2a0cf819198` is HYVE's Proxy BSC address.


- assuming `0x533e3c0e6b48010873B947bddC4721b1bDFF9648` is a valid eth->bsc mpc address.


- mpcAddress on DestToken is `0x533e3c0e6b48010873B947bddC4721b1bDFF9648`. This is the address that has Swapin perms on HYVE BSC.


- have not given mint perms to mpcAddress/DepositAddress `0x533e3c0e6b48010873B947bddC4721b1bDFF9648` on ETH side. let us know if necessary, otherwise I assume it's okay to have mint perms on BSC side & manually send HYVE to the ETH mpcAddress.