### PR TITLE
remove gasnow from list of gas stations for eth mainnet

### DIFF
--- a/crossChain.json
+++ b/crossChain.json
@@ -90,7 +90,7 @@
     ],
     "faucets": [],
     "infoURL": "https://ethereum.org",
-    "gasStations": ["https://www.gasnow.org/api/v3/gas/price"],
+    "gasStations": [],
     "explorers": [
       {
         "name": "etherscan",


### PR DESCRIPTION
gasnow will be ending their service soon, so we ought to remove this from the list of available gas stations for eth mainnet