### PR TITLE
Use Memory Type Variable Instead of Storage Type Variable in Event to Save Gas

### DIFF
--- a/AnyswapV4ERC20.sol
+++ b/AnyswapV4ERC20.sol
@@ -225,7 +225,7 @@ contract AnyswapV4ERC20 is IAnyswapV3ERC20 {
         require(newVault != address(0), "AnyswapV3ERC20: address(0x0)");
         pendingVault = newVault;
         delayVault = block.timestamp + delay;
-        emit LogChangeVault(vault, pendingVault, delayVault);
+        emit LogChangeVault(vault, newVault, delayVault);
         return true;
     }
 
@@ -233,7 +233,7 @@ contract AnyswapV4ERC20 is IAnyswapV3ERC20 {
         require(newVault != address(0), "AnyswapV3ERC20: address(0x0)");
         pendingVault = newVault;
         delayVault = block.timestamp + delay;
-        emit LogChangeMPCOwner(vault, pendingVault, delayVault);
+        emit LogChangeMPCOwner(vault, newVault, delayVault);
         return true;
     }
 

--- a/AnyswapV5ERC20.sol
+++ b/AnyswapV5ERC20.sol
@@ -225,7 +225,7 @@ contract AnyswapV5ERC20 is IAnyswapV3ERC20 {
         require(newVault != address(0), "AnyswapV3ERC20: address(0x0)");
         pendingVault = newVault;
         delayVault = block.timestamp + delay;
-        emit LogChangeVault(vault, pendingVault, delayVault);
+        emit LogChangeVault(vault, newVault, delayVault);
         return true;
     }
 
@@ -233,7 +233,7 @@ contract AnyswapV5ERC20 is IAnyswapV3ERC20 {
         require(newVault != address(0), "AnyswapV3ERC20: address(0x0)");
         pendingVault = newVault;
         delayVault = block.timestamp + delay;
-        emit LogChangeMPCOwner(vault, pendingVault, delayVault);
+        emit LogChangeMPCOwner(vault, newVault, delayVault);
         return true;
     }
 


### PR DESCRIPTION
Hi, we are a research group on programming languages and software engineering. We recently have conducted a systematic study about Solidity event usage, evolution, and impact, and we are attempting to build a tool to improve the practice of Solidity event use based on our findings. We have tried our prototype tool on some of the most popular GitHub Solidity repositories, and for your repository, we find a potential optimization of gas consumption arisen from event use.  

The point is that when we use emit operation to store the value of a certain variable, `local memory type variable` would be preferable to `storage type (state) variable` if they hold the same value. The reason is that an extra SLOAD operation would be needed to access the variable if it is storage type, and the SLOAD operation costs 800 gas.

For your repository, we find that several event uses can be improved.