### PR TITLE
Add ladao-xocolatl to chaindata

### DIFF
--- a/crossChain.json
+++ b/crossChain.json
@@ -779,6 +779,11 @@
         "symbol": "nextKP3R",
         "mainnetEquivalent": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
         "decimals": 18
+      },
+      "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf": {
+        "symbol": "XOC",
+        "mainnetEquivalent": "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
+        "decimals": 18
       }
     },
     "rpc": [

--- a/crossChain.json
+++ b/crossChain.json
@@ -1316,6 +1316,11 @@
         "mainnetEquivalent": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
         "decimals": 18
       },
+      "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf": {
+        "symbol": "XOC",
+        "mainnetEquivalent": "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
+        "decimals": 18
+      },
       "": {
         "symbol": "",
         "mainnetEquivalent": "",

--- a/crossChain.json
+++ b/crossChain.json
@@ -1037,6 +1037,11 @@
         "symbol": "nextKP3R",
         "mainnetEquivalent": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
         "decimals": 18
+      },
+      "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf": {
+        "symbol": "XOC",
+        "mainnetEquivalent": "0xa411c9Aa00E020e4f88Bc19996d29c5B7ADB4ACf",
+        "decimals": 18
       }
     },
     "rpc": [


### PR DESCRIPTION
Following instructions per [xToken Setup Guide](https://connext.notion.site/xTokens-Setup-Guide-be4e136a6db14191b8d61bd60563ebd0#8217720145914d85922af834bac9d267), this pull request intends to add Xocolatl MXN Stablecoin to become `AllowListed`.