### PR TITLE
fix: remove private rpc

### DIFF
--- a/crossChain.json
+++ b/crossChain.json
@@ -216,8 +216,9 @@
       }
     },
     "rpc": [
-      "https://api.mycryptoapi.com/eth",
-      "https://cloudflare-eth.com"
+      "https://eth.llamarpc.com",
+      "https://cloudflare-eth.com",
+      "https://ethereum.publicnode.com"
     ],
     "subgraph": [
       "https://api.thegraph.com/subgraphs/name/connext/nxtp-mainnet-v1-runtime"


### PR DESCRIPTION
The rpc "https://api.mycryptoapi.com/eth" appears to be private as when I query it I get an error message "Forbidden"