### PR TITLE
fix: unblock watcher testing

### DIFF
--- a/crossChain.json
+++ b/crossChain.json
@@ -3223,7 +3223,8 @@
         "symbol": "EURe",
         "decimals": 18
       }
-    }
+    },
+    "rpc": ["https://goerli-rollup.arbitrum.io/rpc"]
   },
   {
     "name": "Gather Network",


### PR DESCRIPTION
Though arbg is RIP
We have unresolved dependencies for it with, like in watcher