### PR TITLE
feat: add gas limit to config

### DIFF
--- a/everclear.testnet.json
+++ b/everclear.testnet.json
@@ -48,6 +48,7 @@
             }
         },
         "97": {
+            "gasLimit": 120000000,
             "providers": [
                 "https://data-seed-prebsc-1-s1.bnbchain.org:8545"
             ],

--- a/everclear.testnet.staging.json
+++ b/everclear.testnet.staging.json
@@ -11,7 +11,8 @@
     "subgraphUrls": [
       "https://api.studio.thegraph.com/query/60851/everclear-hub-scroll-sepolia/version/latest",
       "https://api.goldsky.com/api/public/project_clssc64y57n5r010yeoly05up/subgraphs/everclear-hub-scroll-sepolia/staging-v0.0.7/gn"
-    ]
+    ],
+    "gasLimit": 10000000
   },
   "chains": {
     "11155111": {
@@ -50,6 +51,7 @@
       }
     },
     "97": {
+      "gasLimit": 120000000,
       "providers": [
         "https://data-seed-prebsc-1-s1.bnbchain.org:8545"
       ],


### PR DESCRIPTION
Adds chain gas limit to configuration. Used when calculating the maximum number of elements to dequeue from a given message queue