### PR TITLE
Added ZAI Stablecoin for mainnet and base

### DIFF
--- a/crossChain.json
+++ b/crossChain.json
@@ -311,7 +311,13 @@
         "name": "xTRSY",
         "symbol": "xTRSY",
         "decimals": 18
-      }
+      },
+      "0xb4F40e14Cb88C7e17b5227d5657A4e3b8350770a": {
+        "name": "ZAI Stablecoin",
+        "symbol": "USDz",
+        "mainnetEquivalent": "0x69000405f9dce69bd4cbf4f2865b79144a69bfe0",
+        "decimals": 18
+      },
     },
     "rpc": [
       "https://eth.llamarpc.com",
@@ -3052,6 +3058,11 @@
       "0xA305F2136C4a68d97Ca7BCf7835bfA3b91077661": {
         "name": "xTRSY",
         "symbol": "xTRSY",
+        "decimals": 18
+      },
+      "0x69000cc63be9b4322f3f62c233dd1a7f509ae080": {
+        "name": "ZAI Stablecoin",
+        "symbol": "USDz",
         "decimals": 18
       }
     },

--- a/crossChain.json
+++ b/crossChain.json
@@ -312,7 +312,7 @@
         "symbol": "xTRSY",
         "decimals": 18
       },
-      "0xb4F40e14Cb88C7e17b5227d5657A4e3b8350770a": {
+      "0x6900070DE14ffFAf3A129Dc3880e0153444167Fa": {
         "name": "ZAI Stablecoin",
         "symbol": "USDz",
         "mainnetEquivalent": "0x69000405f9dce69bd4cbf4f2865b79144a69bfe0",


### PR DESCRIPTION
Hello guys, PFA our current setup.

On mainnet we have the ERC20 token deployed here: https://etherscan.io/address/0x69000405f9dce69bd4cbf4f2865b79144a69bfe0

The lockbox deployed here: 
~~https://etherscan.io/address/0x919F0356C049255e20FFe89fE31D34bd4a20B617~~
https://etherscan.io/address/0x278fb6522f962ffd7091ab103618b09aab24ae78

And the XERC20 deployed here: 
~~https://etherscan.io/address/0xb4F40e14Cb88C7e17b5227d5657A4e3b8350770a~~
https://etherscan.io/address/0x6900070DE14ffFAf3A129Dc3880e0153444167Fa

On base chain we have the XERC20 token deployed here: https://basescan.org/address/0x69000cc63be9b4322f3f62c233dd1a7f509ae080

---

Permissions to the bridges should've already been given. But please feel free to recheck.