### PR TITLE
fix: Add Terraform setup step in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,11 @@ jobs:
       - name: Filter empty domain ids
         run: cat crossChain.json | jq 'del(.[] | select(.chainId == null))' > crossChain.tmp && mv -f crossChain.tmp crossChain.json
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.5.7
+
       - name: Terraform Plan
         run: terraform init
 


### PR DESCRIPTION
Introduce a step in the CI workflow to set up Terraform, specifying version 1.5.7 for use in subsequent tasks.