### PR TITLE
add ETH on Solana (only used as destination from other chains on the frontend)

### DIFF
--- a/everclear.json
+++ b/everclear.json
@@ -1243,6 +1243,17 @@
                         "isStable": false,
                         "coingeckoId": "ethereum"
                     }
+                },
+                "ETH": {
+                    "symbol": "ETH",
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "decimals": 8,
+                    "tickerHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "isNative": false,
+                    "price": {
+                        "isStable": false,
+                        "coingeckoId": "ethereum"
+                    }
                 }
             }
         },

--- a/everclear.json
+++ b/everclear.json
@@ -1248,7 +1248,7 @@
                     "symbol": "ETH",
                     "address": "0x0000000000000000000000000000000000000000000000000000000000000000",
                     "decimals": 8,
-                    "tickerHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "tickerHash": "0xaaaebeba3810b1e6b70781f14b2d72c1cb89c0b2b320c43bb67ff79f562f5ff4",
                     "isNative": false,
                     "price": {
                         "isStable": false,


### PR DESCRIPTION
since only the frontend needs it, we may not need this PR and I can just update the frontend configs separately, but there's reasons to have it in config here in case.

1. we want to define the fee config based o chaindata
2. we want to introduce ETH wrapping on the api in the future.
