### PR TITLE
fix: Use Base58Check addresses instead of Hex20 for Tron

### DIFF
--- a/everclear.mainnet.staging.json
+++ b/everclear.mainnet.staging.json
@@ -311,15 +311,15 @@
                 "https://api.goldsky.com/api/public/project_clssc64y57n5r010yeoly05up/subgraphs/everclear-spoke-base/staging-v0.0.1/gn"
             ],
             "deployments": {
-                "everclear": "0xD84173290E0E486B12B973F704CdDEF6E46A308E",
-                "gateway": "0x1F7c443b1793e2223541ee90814FE2a1F8b8778f",
-                "XERC20Module": "0xD84173290E0E486B12B973F704CdDEF6E46A308E"
+                "everclear": "TVgfN2ewsCKmFd4NkP833NQzeFtZRXvp1g",
+                "gateway": "TCqgpCHXGiVbPnEafTK6JGaNjaZFAG3m7Y",
+                "XERC20Module": "TVgfN2ewsCKmFd4NkP833NQzeFtZRXvp1g"
             },
             "confirmations": 1,
             "assets": {
                 "USDT": {
                     "symbol": "USDT",
-                    "address": "0xa614f803B6FD780986A42c78Ec9c7f77e6DeD13C",
+                    "address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
                     "decimals": 6,
                     "tickerHash": "0x8b1a1d9c2b109e527c9134b25b1a1833b16b6594f92daa9f6d9b7a6024bce9d0",
                     "isNative": false,
@@ -330,7 +330,7 @@
                 },
                 "WETH": {
                     "symbol": "WETH",
-                    "address": "0x53908308f4AA220FB10d778B5D1B34489cd6eDfc",
+                    "address": "THb4CqiFdwNHsWsQCs4JhzwjMWys4aqCbF",
                     "decimals": 18,
                     "tickerHash": "0x0f8a193ff464434486c0daf7db2a895884365d2bc84ba47a68fcf89c1b14b5b8",
                     "isNative": false,


### PR DESCRIPTION
we should use base58check address instead of hex20 for tron, same as we use base58 for solana.
- the tron ecosystem uses these addresses almost everywhere, the hex address is not even searchable on tronscan
- the only exception is trongrid api which accepts hex20 format
- the frontend was already converting these addresses internally, but we need to have the address match on the api and frontend to ensure compatibilty
- it's hard to accomodate both formats because the tronweb library expects Base58Check address and throws errors  otherwise.
- the conversion was done with the [Address Util](https://github.com/connext/frontend/blob/2240f05a43ad895536feadd98a72606adf8f8fd5/packages/lib/utils/Address.ts#L164) used by the frontend